### PR TITLE
Fix outputDiffMask NodeJS option

### DIFF
--- a/bin/node-bindings/odiff.js
+++ b/bin/node-bindings/odiff.js
@@ -32,7 +32,7 @@ function optionsToArgs(options) {
         break;
 
       case "outputDiffMask":
-        setFlag("diff-image", value);
+        setFlag("diff-mask", value);
         break;
 
       case "threshold":


### PR DESCRIPTION
Hey,

I noticed when I used the NodeJS bindings with the outputDiffMask option I got the following error:

```
> const { compare } = require("odiff-bin");                                                                           
undefined                                                                                                             
> compare('./1.png', './2.png', './done.png', {outputDiffMask: true}).then(console.log).catch(console.log)            
Promise { <pending> }                                                                                                 
> Error: odiff: unknown option `--diff-image'.
```

I think the flag **--diff-image** isn't available anymore and was replaced with **--diff-mask**