### PR TITLE
Add diff percentage to output

### DIFF
--- a/bin/Main.re
+++ b/bin/Main.re
@@ -61,7 +61,7 @@ let main =
           </Pastel>,
       }
 
-    | Pixel((diffOutput, diffCount)) when diffCount == 0 => {
+    | Pixel((diffOutput, diffCount, _diffPercentage)) when diffCount == 0 => {
         exitCode: 0,
         diff: Some(diffOutput),
         message:
@@ -72,7 +72,7 @@ let main =
           </Pastel>,
       }
 
-    | Pixel((diffOutput, diffCount)) =>
+    | Pixel((diffOutput, diffCount, diffPercentage)) =>
       IO1.saveImage(diffOutput, diffPath);
 
       {
@@ -83,7 +83,9 @@ let main =
             <Pastel color=Red bold=true> "Failure! " </Pastel>
             "Images are different.\n"
             "Different pixels: "
-            <Pastel color=Red bold=true> {Int.to_string(diffCount)} </Pastel>
+            <Pastel color=Red bold=true>
+              {Printf.sprintf("%i (%f%%)", diffCount, diffPercentage)}
+            </Pastel>
           </Pastel>,
       };
     };

--- a/src/Diff.re
+++ b/src/Diff.re
@@ -3,7 +3,7 @@ let maxYIQPossibleDelta = 35215.;
 
 type diffVariant('a) =
   | Layout
-  | Pixel(('a, int));
+  | Pixel(('a, int, float));
 
 module MakeDiff = (IO1: ImageIO.ImageIO, IO2: ImageIO.ImageIO) => {
   let compare =
@@ -53,7 +53,12 @@ module MakeDiff = (IO1: ImageIO.ImageIO, IO2: ImageIO.ImageIO) => {
       };
     };
 
-    (diffOutput, diffCount^);
+    let diffPercentage =
+      100.0
+      *. Float.of_int(diffCount^)
+      /. (Float.of_int(base.width) *. Float.of_int(base.height));
+
+    (diffOutput, diffCount^, diffPercentage);
   };
 
   let diff =

--- a/test/PngTests.re
+++ b/test/PngTests.re
@@ -8,27 +8,30 @@ describe("Png comparing", ({test, _}) => {
     let img1 = PureC_IO.IO.loadImage("test/test-images/orange.png");
     let img2 = PureC_IO.IO.loadImage("test/test-images/orange_changed.png");
 
-    let (_, diffPixels) = Diff.compare(img1, img2, ());
+    let (_, diffPixels, diffPercentage) = Diff.compare(img1, img2, ());
     expect.int(diffPixels).toBe(1430);
+    expect.float(diffPercentage).toBeCloseTo(1.20);
   });
 
   test("uses provided threshold", ({expect, _}) => {
     let img1 = PureC_IO.IO.loadImage("test/test-images/orange.png");
     let img2 = PureC_IO.IO.loadImage("test/test-images/orange_changed.png");
 
-    let (_, diffPixels) = Diff.compare(img1, img2, ~threshold=0.5, ());
+    let (_, diffPixels, diffPercentage) =
+      Diff.compare(img1, img2, ~threshold=0.5, ());
     expect.int(diffPixels).toBe(222);
+    expect.float(diffPercentage).toBeCloseTo(0.19);
   });
 
   test("creates the right diff output image", ({expect, _}) => {
     let img1 = PureC_IO.IO.loadImage("test/test-images/orange.png");
     let img2 = PureC_IO.IO.loadImage("test/test-images/orange_changed.png");
 
-    let (diffOutput, _) = Diff.compare(img1, img2, ());
+    let (diffOutput, _, _) = Diff.compare(img1, img2, ());
 
     let originalDiff =
       PureC_IO.IO.loadImage("test/test-images/orange_diff.png");
-    let (diffMaskOfDiff, diffOfDiffPixels) =
+    let (diffMaskOfDiff, diffOfDiffPixels, diffOfDiffPercentage) =
       Diff.compare(originalDiff, diffOutput, ());
 
     if (diffOfDiffPixels > 0) {
@@ -40,6 +43,7 @@ describe("Png comparing", ({test, _}) => {
     };
 
     expect.int(diffOfDiffPixels).toBe(0);
+    expect.float(diffOfDiffPercentage).toBeCloseTo(0.0);
   });
 
   test(
@@ -48,12 +52,12 @@ describe("Png comparing", ({test, _}) => {
     let img1 = PureC_IO.IO.loadImage("test/test-images/orange.png");
     let img2 = PureC_IO.IO.loadImage("test/test-images/orange_changed.png");
 
-    let (diffOutput, _) =
+    let (diffOutput, _, _) =
       Diff.compare(img1, img2, ~diffPixel=(0, 255, 0), ());
 
     let originalDiff =
       PureC_IO.IO.loadImage("test/test-images/orange_diff_green.png");
-    let (diffMaskOfDiff, diffOfDiffPixels) =
+    let (diffMaskOfDiff, diffOfDiffPixels, diffOfDiffPercentage) =
       Diff.compare(originalDiff, diffOutput, ());
 
     if (diffOfDiffPixels > 0) {
@@ -68,5 +72,6 @@ describe("Png comparing", ({test, _}) => {
     };
 
     expect.int(diffOfDiffPixels).toBe(0);
+    expect.float(diffOfDiffPercentage).toBeCloseTo(0.0);
   });
 });


### PR DESCRIPTION
This adds the diff in percentage to the output.
The format now is "Different pixels: 7586 (1.137331%)"

![Output](https://user-images.githubusercontent.com/7459510/113175484-c0378a80-924b-11eb-906c-1fdc5a71b2d7.png)

Fixes #8 
