### PR TITLE
Remove rewritePrefix

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "build": "dune build -p #{self.name}",
     "buildDev": "refmterr dune build --promote-install-files --root . --only-package #{self.name}",
     "release": {
-      "rewritePrefix": true,
       "bin": {
         "odiff": "ODiffBin"
       },


### PR DESCRIPTION
Fixes #29 

Releases configured with `"esy.release.rewritePrefix": true` cannot be installed into deep filesystem locations (the limit is around 108 characters).

@dmtrKovalenko Do you know, if we need this for `esy-libpng` or `esy-zlib`?