### PR TITLE
increase performance of color checks

### DIFF
--- a/io/CamlImagesIO.re
+++ b/io/CamlImagesIO.re
@@ -30,7 +30,7 @@ module IO: ImageIO.ImageIO = {
     let b = Char.code(Bytes.unsafe_get(bytes, position + 2)) land 0xFF;
     let a = Char.code(Bytes.unsafe_get(bytes, position + 3)) land 0xFF;
 
-    Int32.of_int(a lsl 24 + r lsl 16 + g lsl 8 + b);
+    Int32.of_int(a lsl 24 + b lsl 16 + g lsl 8 + r);
   };
 
   let readImgColor = (x, y, img: ImageIO.img(t)) =>

--- a/io/CamlImagesIO.re
+++ b/io/CamlImagesIO.re
@@ -25,12 +25,12 @@ module IO: ImageIO.ImageIO = {
   let readDirectPixel = (~x, ~y, img: ImageIO.img(Rgba32.t)) => {
     let (bytes, position) = Rgba32.unsafe_access(img.image, x, y);
 
-    (
-      Bytes.unsafe_get(bytes, position) |> Char.code,
-      Bytes.unsafe_get(bytes, position + 1) |> Char.code,
-      Bytes.unsafe_get(bytes, position + 2) |> Char.code,
-      Bytes.unsafe_get(bytes, position + 3) |> Char.code,
-    );
+    let r = Char.code(Bytes.unsafe_get(bytes, position + 0)) land 0xFF;
+    let g = Char.code(Bytes.unsafe_get(bytes, position + 1)) land 0xFF;
+    let b = Char.code(Bytes.unsafe_get(bytes, position + 2)) land 0xFF;
+    let a = Char.code(Bytes.unsafe_get(bytes, position + 3)) land 0xFF;
+
+    Int32.of_int(a lsl 24 + r lsl 16 + g lsl 8 + b);
   };
 
   let readImgColor = (x, y, img: ImageIO.img(t)) =>

--- a/io/PureC_IO.re
+++ b/io/PureC_IO.re
@@ -8,7 +8,12 @@ module IO: Odiff.ImageIO.ImageIO = {
   };
 
   let readImgColor = (x, row: row, _img: Odiff.ImageIO.img(t)) => {
-    (row.{x * 4}, row.{x * 4 + 1}, row.{x * 4 + 2}, row.{x * 4 + 3});
+    let r = row.{x * 4 + 0} land 0xFF;
+    let g = row.{x * 4 + 1} land 0xFF;
+    let b = row.{x * 4 + 2} land 0xFF;
+    let a = row.{x * 4 + 3} land 0xFF;
+
+    Int32.of_int(a lsl 24 + r lsl 16 + g lsl 8 + b);
   };
 
   let setImgColor = (x, y, pixel, img: Odiff.ImageIO.img(t)) => {

--- a/io/PureC_IO.re
+++ b/io/PureC_IO.re
@@ -1,19 +1,13 @@
 module IO: Odiff.ImageIO.ImageIO = {
   type t = int;
-  type row =
-    Bigarray.Array1.t(int, Bigarray.int8_unsigned_elt, Bigarray.c_layout);
+  type row = Bigarray.Array1.t(int32, Bigarray.int32_elt, Bigarray.c_layout);
 
   let readRow = (img: Odiff.ImageIO.img(t), y): row => {
     ReadPng.read_row(img.image, y, img.width);
   };
 
   let readImgColor = (x, row: row, _img: Odiff.ImageIO.img(t)) => {
-    let r = row.{x * 4 + 0} land 0xFF;
-    let g = row.{x * 4 + 1} land 0xFF;
-    let b = row.{x * 4 + 2} land 0xFF;
-    let a = row.{x * 4 + 3} land 0xFF;
-
-    Int32.of_int(a lsl 24 + r lsl 16 + g lsl 8 + b);
+    row.{x};
   };
 
   let setImgColor = (x, y, pixel, img: Odiff.ImageIO.img(t)) => {

--- a/io/PureC_IO_Bigarray.re
+++ b/io/PureC_IO_Bigarray.re
@@ -9,14 +9,7 @@ module IO: Odiff.ImageIO.ImageIO = {
 
   type row = int;
   let readDirectPixel = (~x: int, ~y: int, img) => {
-    let pixel = (img.image.bigarray).{y * img.width + x} |> Int32.to_int;
-
-    let a = pixel lsr 24 land 0xFF;
-    let r = pixel lsr 16 land 0xFF;
-    let g = pixel lsr 8 land 0xFF;
-    let b = pixel land 0xFF;
-
-    (r, g, b, a);
+    (img.image.bigarray).{y * img.width + x};
   };
 
   let readRow = (img: Odiff.ImageIO.img(t), y): row => y;

--- a/io/ReadPng.c
+++ b/io/ReadPng.c
@@ -151,8 +151,8 @@ read_row(png_bytep *row_pointers, value y_val, value img_width_val)
 
   png_bytep row = row_pointers[y];
 
-  long dims[] = {img_width * 4};
-  CAMLreturn(caml_ba_alloc(CAML_BA_UINT8 | CAML_BA_C_LAYOUT, 1, row, dims));
+  long dims[] = {img_width};
+  CAMLreturn(caml_ba_alloc(CAML_BA_INT32 | CAML_BA_C_LAYOUT, 1, row, dims));
 }
 
 CAMLprim value

--- a/src/Antialiasing.re
+++ b/src/Antialiasing.re
@@ -17,13 +17,11 @@ module MakeAntialiasing = (IO1: ImageIO.ImageIO, IO2: ImageIO.ImageIO) => {
       // go through 8 adjacent pixels
       for (adj_y in y0 to y1) {
         for (adj_x in x0 to x1) {
-          /* This is the current pixel or we already have our result, do nothing */
-          if (x == adj_x && y == adj_y || zeroes^ >= 3) {
-            ();
-          } else {
+          /* This is not the current pixel and we don't have our result */
+          if (zeroes^ < 3 && (x != adj_x || y != adj_y)) {
             let adjacentColor = readColor(~x=adj_x, ~y=adj_y);
-            if (Helpers.isSameColor(baseColor, adjacentColor)) {
-              zeroes := zeroes^ + 1;
+            if (baseColor == adjacentColor) {
+              incr(zeroes);
             };
           };
         };
@@ -53,14 +51,13 @@ module MakeAntialiasing = (IO1: ImageIO.ImageIO, IO2: ImageIO.ImageIO) => {
 
     for (adj_y in y0 to y1) {
       for (adj_x in x0 to x1) {
-        /* This is the current pixel or we already know, this is not anti-aliasing, do nothing */
-        if (x == adj_x && y == adj_y || zeroes^ >= 3) {
-          ();
-        } else {
-          let adjacentColor = baseImg |> IO1.readDirectPixel(~x=adj_x, ~y=adj_y);
+        /* This is not the current pixel and we don't have our result */
+        if (zeroes^ < 3 && (x != adj_x || y != adj_y)) {
+          let adjacentColor =
+            baseImg |> IO1.readDirectPixel(~x=adj_x, ~y=adj_y);
 
-          if (Helpers.isSameColor(baseColor, adjacentColor)) {
-            zeroes := zeroes^ + 1;
+          if (baseColor == adjacentColor) {
+            incr(zeroes);
           } else {
             let delta =
               ColorDelta.calculatePixelBrightnessDelta(

--- a/src/ColorDelta.re
+++ b/src/ColorDelta.re
@@ -1,21 +1,24 @@
-let blend = (color, alpha) => 255 + (color - 255) * alpha;
+let blend = (color, alpha) => 255. +. (color -. 255.) *. alpha;
 
 let blendSemiTransparentColor =
   fun
-  | (r, g, b, alpha) when alpha < 255 => (
+  | (r, g, b, alpha) when alpha < 255. => (
       blend(r, alpha),
       blend(g, alpha),
       blend(b, alpha),
-      alpha / 255,
+      alpha /. 255.,
     )
   | colors => colors;
 
-let convertPixelToFloat = ((r, g, b, a)) => (
-  Float.of_int(r),
-  Float.of_int(g),
-  Float.of_int(b),
-  Float.of_int(a),
-);
+let convertPixelToFloat = pixel => {
+  let pixel = pixel |> Int32.to_int;
+  let a = pixel lsr 24 land 0xFF;
+  let r = pixel lsr 16 land 0xFF;
+  let g = pixel lsr 8 land 0xFF;
+  let b = pixel land 0xFF;
+
+  (Float.of_int(r), Float.of_int(g), Float.of_int(b), Float.of_int(a));
+};
 
 let rgb2y = ((r, g, b, a)) =>
   r *. 0.29889531 +. g *. 0.58662247 +. b *. 0.11448223;
@@ -27,8 +30,8 @@ let rgb2q = ((r, g, b, a)) =>
   r *. 0.21147017 -. g *. 0.52261711 +. b *. 0.31114694;
 
 let calculatePixelColorDelta = (_pixelA, _pixelB) => {
-  let pixelA = _pixelA |> blendSemiTransparentColor |> convertPixelToFloat;
-  let pixelB = _pixelB |> blendSemiTransparentColor |> convertPixelToFloat;
+  let pixelA = _pixelA |> convertPixelToFloat |> blendSemiTransparentColor;
+  let pixelB = _pixelB |> convertPixelToFloat |> blendSemiTransparentColor;
 
   let y = rgb2y(pixelA) -. rgb2y(pixelB);
   let i = rgb2i(pixelA) -. rgb2i(pixelB);
@@ -38,8 +41,8 @@ let calculatePixelColorDelta = (_pixelA, _pixelB) => {
 };
 
 let calculatePixelBrightnessDelta = (pixelA, pixelB) => {
-  let pixelA = pixelA |> blendSemiTransparentColor |> convertPixelToFloat;
-  let pixelB = pixelB |> blendSemiTransparentColor |> convertPixelToFloat;
+  let pixelA = pixelA |> convertPixelToFloat |> blendSemiTransparentColor;
+  let pixelB = pixelB |> convertPixelToFloat |> blendSemiTransparentColor;
 
   rgb2y(pixelA) -. rgb2y(pixelB);
 };

--- a/src/ColorDelta.re
+++ b/src/ColorDelta.re
@@ -13,9 +13,9 @@ let blendSemiTransparentColor =
 let convertPixelToFloat = pixel => {
   let pixel = pixel |> Int32.to_int;
   let a = pixel lsr 24 land 0xFF;
-  let r = pixel lsr 16 land 0xFF;
+  let b = pixel lsr 16 land 0xFF;
   let g = pixel lsr 8 land 0xFF;
-  let b = pixel land 0xFF;
+  let r = pixel land 0xFF;
 
   (Float.of_int(r), Float.of_int(g), Float.of_int(b), Float.of_int(a));
 };

--- a/src/Diff.re
+++ b/src/Diff.re
@@ -34,8 +34,10 @@ module MakeDiff = (IO1: ImageIO.ImageIO, IO2: ImageIO.ImageIO) => {
 
       for (x in 0 to base.width - 1) {
         if (x >= comp.width || y >= comp.height) {
-          let (_r, _g, _b, a) = IO1.readImgColor(x, row, base);
-          if (a != 0) {
+          let alpha =
+            Int32.to_int(IO1.readImgColor(x, row, base)) lsr 24 land 0xFF;
+
+          if (alpha != 0) {
             countDifference(x, y);
           };
         } else {

--- a/src/Diff.re
+++ b/src/Diff.re
@@ -24,7 +24,7 @@ module MakeDiff = (IO1: ImageIO.ImageIO, IO2: ImageIO.ImageIO) => {
     let diffOutput = outputDiffMask ? IO1.makeSameAsLayout(base) : base;
 
     let countDifference = (x, y) => {
-      diffCount := diffCount^ + 1;
+      incr(diffCount);
       diffOutput |> IO1.setImgColor(x, y, diffPixel);
     };
 
@@ -42,7 +42,7 @@ module MakeDiff = (IO1: ImageIO.ImageIO, IO2: ImageIO.ImageIO) => {
           let baseColor = IO1.readImgColor(x, row, base);
           let compColor = IO2.readImgColor(x, row2, comp);
 
-          if (!Helpers.isSameColor(baseColor, compColor)) {
+          if (baseColor != compColor) {
             let delta =
               ColorDelta.calculatePixelColorDelta(baseColor, compColor);
 

--- a/src/Helpers.re
+++ b/src/Helpers.re
@@ -1,6 +1,1 @@
-let isSameColor = (a, b) => {
-  let (base_r, base_g, base_b, base_a) = a;
-  let (comp_r, comp_g, comp_b, comp_a) = b;
 
-  base_r == comp_r && base_g == comp_g && base_b == comp_b && base_a == comp_a;
-};

--- a/src/ImageIO.re
+++ b/src/ImageIO.re
@@ -13,10 +13,10 @@ module type ImageIO = {
 
   let loadImage: string => img(t);
   let readRow: (img(t), int) => row;
-  let readImgColor: (int, row, img(t)) => (int, int, int, int);
+  let readImgColor: (int, row, img(t)) => Int32.t;
   let setImgColor: (int, int, rgb_pixel, img(t)) => unit;
   let saveImage: (img(t), string) => unit;
   let freeImage: img(t) => unit;
   let makeSameAsLayout: img(t) => img(t);
-  let readDirectPixel: (~x: int, ~y:int, img(t)) => (int, int, int, int);
+  let readDirectPixel: (~x: int, ~y: int, img(t)) => Int32.t;
 };


### PR DESCRIPTION
This removes the `isSameColor` helper function and replaces it with a simple equality check on the two tuples.
In my tests this increased the performance of the 4k-water image by roughly 300ms.

I also cleaned up some of the antialiasing code. These are just cosmetic changes though 🙂 