### PR TITLE
feat: add ignore-regions

### DIFF
--- a/bin/Main.re
+++ b/bin/Main.re
@@ -28,6 +28,7 @@ let main =
       diffColorHex,
       stdoutParsableString,
       antialiasing,
+      ignoreRegions,
     ) => {
   module IO1 = (val getIOModule(img1Path, ~antialiasing));
   module IO2 = (val getIOModule(img2Path, ~antialiasing));
@@ -45,6 +46,7 @@ let main =
       ~threshold,
       ~failOnLayoutChange,
       ~antialiasing,
+      ~ignoreRegions,
       ~diffPixel=
         Color.ofHexString(diffColorHex)
         |> (

--- a/bin/ODiffBin.re
+++ b/bin/ODiffBin.re
@@ -56,7 +56,7 @@ let failOnLayout =
           "Do not compare images and produce output if images layout is different.",
       )
   );
-  
+
 let parsableOutput =
   Arg.(
     value
@@ -64,11 +64,9 @@ let parsableOutput =
     & info(
         ["parsable-stdout"],
         ~docv="PARSABLE_OUTPUT",
-        ~doc=
-          "Stdout parsable output",
+        ~doc="Stdout parsable output",
       )
   );
-
 
 let diffColor =
   Arg.(
@@ -93,6 +91,18 @@ let antialiasing = {
   );
 };
 
+let ignoreRegions = {
+  Arg.(
+    value
+    & opt(list(~sep='+', t4(int, int, int, int)), [])
+    & info(
+        ["i", "ignore"],
+        ~doc=
+          "An array of regions to ignore in the diff. One region consists of four numbers (x, y, width, height). Multiple regions are separated with a '+'.",
+      )
+  );
+};
+
 let cmd = {
   let man = [
     `S(Manpage.s_description),
@@ -112,6 +122,7 @@ let cmd = {
       $ diffColor
       $ parsableOutput
       $ antialiasing
+      $ ignoreRegions
     ),
     Term.info(
       "odiff",

--- a/bin/node-bindings/odiff.d.ts
+++ b/bin/node-bindings/odiff.d.ts
@@ -9,6 +9,8 @@ export type ODiffOptions = {
   threshold: number;
   /** If this is true, antialiased pixels are not counted to the diff of an image */
   antialiasing: boolean;
+  /** An array of regions to ignore in the diff. One region consists of four numbers (x, y, width, height) */
+  ignoreRegions: Array<Array<number>>;
 };
 
 declare function compare(

--- a/bin/node-bindings/odiff.js
+++ b/bin/node-bindings/odiff.js
@@ -45,6 +45,15 @@ function optionsToArgs(options) {
       case "antialiasing":
         setArgWithValue("antialiasing", value);
         break;
+
+      case "ignoreRegions": {
+        const regions = value
+          .map((region) => `${region[0]},${region[1]},${region[2]},${region[3]}`)
+          .join('+');
+
+        argArray.push(`--ignore=${regions}`);
+        break;
+      }
     }
   });
 

--- a/src/Diff.re
+++ b/src/Diff.re
@@ -5,6 +5,15 @@ type diffVariant('a) =
   | Layout
   | Pixel(('a, int, float));
 
+let isInIgnoreRegion = (x, y, regions) => {
+  List.exists(
+    ((rx, ry, width, height)) => {
+      x >= rx && x <= rx + width && y >= ry && y <= ry + height
+    },
+    regions,
+  );
+};
+
 module MakeDiff = (IO1: ImageIO.ImageIO, IO2: ImageIO.ImageIO) => {
   module BaseAA = Antialiasing.MakeAntialiasing(IO1, IO2);
   module CompAA = Antialiasing.MakeAntialiasing(IO2, IO1);
@@ -17,6 +26,7 @@ module MakeDiff = (IO1: ImageIO.ImageIO, IO2: ImageIO.ImageIO) => {
         ~outputDiffMask=false,
         ~diffPixel: (int, int, int)=redPixel,
         ~threshold=0.1,
+        ~ignoreRegions=[],
         (),
       ) => {
     let diffCount = ref(0);
@@ -33,7 +43,9 @@ module MakeDiff = (IO1: ImageIO.ImageIO, IO2: ImageIO.ImageIO) => {
       let row2 = IO2.readRow(comp, y);
 
       for (x in 0 to base.width - 1) {
-        if (x >= comp.width || y >= comp.height) {
+        if (isInIgnoreRegion(x, y, ignoreRegions)) {
+          ();
+        } else if (x >= comp.width || y >= comp.height) {
           let (_r, _g, _b, a) = IO1.readImgColor(x, row, base);
           if (a != 0) {
             countDifference(x, y);
@@ -81,6 +93,7 @@ module MakeDiff = (IO1: ImageIO.ImageIO, IO2: ImageIO.ImageIO) => {
         ~diffPixel=redPixel,
         ~failOnLayoutChange=true,
         ~antialiasing=false,
+        ~ignoreRegions=[],
         (),
       ) =>
     if (failOnLayoutChange == true
@@ -96,6 +109,7 @@ module MakeDiff = (IO1: ImageIO.ImageIO, IO2: ImageIO.ImageIO) => {
           ~diffPixel,
           ~outputDiffMask,
           ~antialiasing,
+          ~ignoreRegions,
           (),
         );
 

--- a/test/PngTests.re
+++ b/test/PngTests.re
@@ -26,6 +26,22 @@ describe("Png comparing", ({test, _}) => {
     expect.float(diffPercentage).toBeCloseTo(0.19);
   });
 
+  test("uses provided irgnore regions", ({expect, _}) => {
+    let img1 = PureC_IO.IO.loadImage("test/test-images/orange.png");
+    let img2 = PureC_IO.IO.loadImage("test/test-images/orange_changed.png");
+
+    let (_diffOutput, diffPixels, diffPercentage) =
+      Diff.compare(
+        img1,
+        img2,
+        ~ignoreRegions=[(150, 30, 160, 75), (20, 175, 85, 25)],
+        (),
+      );
+
+    expect.int(diffPixels).toBe(0);
+    expect.float(diffPercentage).toBeCloseTo(0.0);
+  });
+
   test("creates the right diff output image", ({expect, _}) => {
     let img1 = PureC_IO.IO.loadImage("test/test-images/orange.png");
     let img2 = PureC_IO.IO.loadImage("test/test-images/orange_changed.png");

--- a/test/node-binding.test.cjs
+++ b/test/node-binding.test.cjs
@@ -47,6 +47,23 @@ test("Correctly parses cli arguments", async (t) => {
   t.is(diffPercentage, 1.31007003768);
 });
 
+test("Correctly parses ignore regions", async (t) => {
+  const { match } = await compare(
+    path.join(IMAGES_PATH, "donkey.png"),
+    path.join(IMAGES_PATH, "donkey-2.png"),
+    path.join(IMAGES_PATH, "diff.png"),
+    {
+      ignoreRegions: [
+        [749, 1155, 421, 448],
+        [657, 1278, 85, 56]
+      ],
+      __binaryPath: BINARY_PATH,
+    }
+  )
+
+  t.is(match, true);
+});
+
 test("Outputs correct parsed result when images different for cypress image", async (t) => {
   const { reason, diffCount, diffPercentage } = await compare(
     path.join(IMAGES_PATH, "www.cypress.io.png"),


### PR DESCRIPTION
This adds the ignore-regions.

I don't know if i am happy with the cli syntax for defining multiple regions.
Currently it looks like this:

```
odiff --ignore 1,2,3,4+5,6,7,8
```

The comma separates the x, y, width and height numbers and the plus separates multiple ignore-regions.
I would have liked an `;`, but this terminates the command.
If you have any ideas, let me know 🙂 