### PR TITLE
Fix #43

### DIFF
--- a/src/Diff.re
+++ b/src/Diff.re
@@ -96,8 +96,7 @@ module MakeDiff = (IO1: ImageIO.ImageIO, IO2: ImageIO.ImageIO) => {
         (),
       ) =>
     if (failOnLayoutChange == true
-        && base.width != comp.width
-        && base.height != comp.height) {
+        && (base.width != comp.width || base.height != comp.height)) {
       Layout;
     } else {
       let diffResult =


### PR DESCRIPTION
This changes the behavior of `failOnLayoutChange`, so that it fails if width _or_ height are different.
Previously it only failed if width _and_ height were different.

Fixes #43 