### PR TITLE
Add a ODiff cypress plugin link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ const { match, reason } = await compare(
 );
 ```
 
+### Cypress
+Checkout [cypress-odiff](https://github.com/odai-alali/cypress-odiff), a cypress plugin to add visual regression tests using `odiff-bin`.
+
 ## Api
 
 Here is an api reference:


### PR DESCRIPTION
Hello @dmtrKovalenko 

Thanks for your work on ODiff. I'm working on a project where we have more than 440 screenshots to compare, and we implemented the visual regression tests with a cypress plugin that uses `pixelmatch` under the hood.

After implementing another plugin using `odiff`, the visual regression tests time was reduced more than 60%. So I published a cypress plugin for odiff and I thought it would be nice to have a section about it in Usages.