### PR TITLE
fix: add name to dune-project file

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -11,6 +11,7 @@
 
 (generate_opam_files true)
 
+(name odiff)
 (source (github dmtrKovalenko/odiff))
 (license MIT)
 (authors "Dmitriy Kovalenko")


### PR DESCRIPTION
This adds a name into the dune-project file. 
Not having this, leads to an error when trying to install odiff with opam: 

```
[ERROR] The compilation of odiff-core.dev failed at "dune subst".

#=== ERROR while compiling odiff-core.dev =====================================#
# context     2.1.3 | macos/x86_64 |  | pinned(git+https://github.com/dmtrKovalenko/odiff.git#075c6b7a)
# path        ~/Documents/Projekte/space-labs/osnap/_opam/.opam-switch/build/odiff-core.dev
# command     ~/.opam/opam-init/hooks/sandbox.sh build dune subst
# exit-code   1
# env-file    ~/.opam/log/odiff-core-8927-3eb552.env
# output-file ~/.opam/log/odiff-core-8927-3eb552.out

### output ###
# Error: The project name is not defined, please add a (name <name>) field to
# your dune-project file.
```