### PR TITLE
Fix broken link to YIQ NTSC reference paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ ODiff is a blazing fast native image comparison tool. Check [benchmarks](#benchm
 - ✅ Anti-aliasing detection
 - ✅ Ignoring regions
 - ✅ Using [YIQ NTSC
-  transmission algorithm](http://www.progmat.uaem.mx:8080/artVol2Num2/Articulo3Vol2Num2.pdf) to determine visual difference.
+  transmission algorithm](https://progmat.uaem.mx/progmat/index.php/progmat/article/view/2010-2-2-03/2010-2-2-03) to determine visual difference.
 
 ### Coming in the nearest future:
 


### PR DESCRIPTION
## Changes

Link in README.md appears to point to an old address for "Measuring perceived color difference using YIQ NTSC transmission color space in mobile applications" (Kotsarenko & Ramos 2010).

This change substitutes a link to the current journal site.

## Motivation

Here from https://github.com/lucasb-eyer/go-colorful/issues/55.