### PR TITLE
Normalize alpha before blending for correct RGB values and distance

### DIFF
--- a/src/ColorDelta.ml
+++ b/src/ColorDelta.ml
@@ -2,7 +2,13 @@ let blend color alpha = 255. +. ((color -. 255.) *. alpha)
 
 let blendSemiTransparentColor = function
   | r, g, b, alpha when alpha < 255. ->
-      (blend r alpha, blend g alpha, blend b alpha, alpha /. 255.)
+      let normalizedAlpha = alpha /. 255. in
+      let (r, g, b, a) = (blend r normalizedAlpha, blend g normalizedAlpha, blend b normalizedAlpha, normalizedAlpha) in
+      assert (r >= 0. && r <= 255.);
+      assert (g >= 0. && g <= 255.);
+      assert (b >= 0. && b <= 255.);
+      assert (a >= 0. && a <= 1.);
+      (r, g, b, a)
   | colors -> colors
 
 let convertPixelToFloat pixel =
@@ -28,7 +34,9 @@ let calculatePixelColorDelta _pixelA _pixelB =
   let y = rgb2y pixelA -. rgb2y pixelB in
   let i = rgb2i pixelA -. rgb2i pixelB in
   let q = rgb2q pixelA -. rgb2q pixelB in
-  (0.5053 *. y *. y) +. (0.299 *. i *. i) +. (0.1957 *. q *. q)
+  let delta = (0.5053 *. y *. y) +. (0.299 *. i *. i) +. (0.1957 *. q *. q) in
+  assert (delta < 35215.);
+  delta
 
 let calculatePixelBrightnessDelta pixelA pixelB =
   let pixelA = pixelA |> convertPixelToFloat |> blendSemiTransparentColor in


### PR DESCRIPTION
In the base branch, alpha values passed to the `blend` function are not normalized to 0.0 to 1.0. So, the blending can generate invalid RGB values outside the range of 0 to 255, especially negative RGB values. As a consequence, the value range of color distance exceeds the `maxYIQPossibleDelta = 35215`. So, I've added these assertions for RGB and distance, which fail in existing test cases.

I've added normalization to the alpha values. However, we still need to update existing test cases that count different pixels with new correct assertions.