### PR TITLE
chore: remove upper ocaml constraint for opam

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -11,6 +11,7 @@
 
 (generate_opam_files true)
 
+(name odiff)
 (source (github dmtrKovalenko/odiff))
 (license MIT)
 (authors "Dmitriy Kovalenko")

--- a/dune-project
+++ b/dune-project
@@ -30,8 +30,8 @@
  (synopsis "Pixel-by-pixel image difference algorithm")
  (depends
   dune
-  (reason (and (>= 3.6.0) (< 4.0.0)))
-  (ocaml (and (>= 4.10.0) (< 5.0.0)))
+  (reason (>= 3.6.0))
+  (ocaml (>= 4.10.0))
  )
 )
 
@@ -42,7 +42,7 @@
   dune
   conf-libpng
   odiff-core
-  (reason (and (>= 3.6.0) (< 4.0.0)))
-  (ocaml (and (>= 4.10.0) (< 4.11.0)))
+  (reason (>= 3.6.0))
+  (ocaml (>= 4.10.0))
  )
 )

--- a/odiff-core.opam
+++ b/odiff-core.opam
@@ -8,8 +8,8 @@ homepage: "https://github.com/dmtrKovalenko/odiff"
 bug-reports: "https://github.com/dmtrKovalenko/odiff/issues"
 depends: [
   "dune" {>= "2.8"}
-  "reason" {>= "3.6.0" & < "4.0.0"}
-  "ocaml" {>= "4.10.0" & < "5.0.0"}
+  "reason" {>= "3.6.0"}
+  "ocaml" {>= "4.10.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/odiff-io.opam
+++ b/odiff-io.opam
@@ -10,8 +10,8 @@ depends: [
   "dune" {>= "2.8"}
   "conf-libpng"
   "odiff-core"
-  "reason" {>= "3.6.0" & < "4.0.0"}
-  "ocaml" {>= "4.10.0" & < "4.11.0"}
+  "reason" {>= "3.6.0"}
+  "ocaml" {>= "4.10.0"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
This also has the changes from #73. 

Currently you can't install odiff in a > 5.0.0 ocaml switch. I would like to lift this constraint for integration in osnap.