### PR TITLE
Make the diffPath optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ ODiff is a blazing fast native image comparison tool. Check [benchmarks](#benchm
 
 ### Basic comparison
 
-Run the simple comparison. Image paths can be one of supported formats, diff output can only be `.png`.
+Run the simple comparison. Image paths can be one of supported formats, diff output is optional and can only be `.png`.
 
 ```
-odiff <IMG1 path> <IMG2 path> <DIFF output path>
+odiff <IMG1 path> <IMG2 path> [DIFF output path]
 ```
 
 ### Node.js

--- a/bin/Main.ml
+++ b/bin/Main.ml
@@ -60,7 +60,7 @@ let main img1Path img2Path diffPath threshold outputDiffMask failOnLayoutChange
       ->
         { exitCode = 0; diff = Some diffOutput }
     | Pixel (diffOutput, diffCount, diffPercentage, _) ->
-        IO1.saveImage diffOutput diffPath;
+        diffPath |> Option.iter (IO1.saveImage diffOutput);
         { exitCode = 22; diff = Some diffOutput }
   in
   IO1.freeImage img1;

--- a/bin/ODiffBin.ml
+++ b/bin/ODiffBin.ml
@@ -3,8 +3,8 @@ open Term
 open Arg
 
 let diffPath =
-  value & pos 2 string ""
-  & info [] ~docv:"DIFF" ~doc:"Diff output path (.png only)"
+  value & pos 2 (some string) None
+  & info [] ~docv:"DIFF" ~doc:"Optional Diff output path (.png only)"
 
 let base =
   value & pos 0 file "" & info [] ~docv:"BASE" ~doc:"Path to base image"

--- a/test/Test_Core.ml
+++ b/test/Test_Core.ml
@@ -48,10 +48,14 @@ let test_diff_color () =
       ~diffPixel:(Int32.of_int 4278255360 (*int32 representation of #00ff00*))
       ()
   in
+  check bool "diffOutput" (Option.is_some diffOutput) true;
+  let diffOutput = Option.get diffOutput in
   let originalDiff = Png.IO.loadImage "test-images/png/orange_diff_green.png" in
   let diffMaskOfDiff, diffOfDiffPixels, diffOfDiffPercentage, _ =
     PNG_Diff.compare originalDiff diffOutput ()
   in
+  check bool "diffMaskOfDiff" (Option.is_some diffMaskOfDiff) true;
+  let diffMaskOfDiff = Option.get diffMaskOfDiff in
   if diffOfDiffPixels > 0 then (
     Png.IO.saveImage diffOutput "test-images/png/diff-output-green.png";
     Png.IO.saveImage diffMaskOfDiff "test-images/png/diff-of-diff-green.png");

--- a/test/Test_IO_BMP.ml
+++ b/test/Test_IO_BMP.ml
@@ -34,8 +34,12 @@ let test_creates_correct_diff_output_image () =
   let img1 = load_image "test-images/bmp/clouds.bmp" in
   let img2 = load_image "test-images/bmp/clouds-2.bmp" in
   let diffOutput, _, _, _ = Diff.compare img1 img2 () in
+  check bool "diffOutput" (Option.is_some diffOutput) true;
+  let diffOutput = Option.get diffOutput in
   let originalDiff = load_png_image "test-images/bmp/clouds-diff.png" in
   let diffMaskOfDiff, diffOfDiffPixels, diffOfDiffPercentage, _ = Output_Diff.compare originalDiff diffOutput () in
+  check bool "diffMaskOfDiff" (Option.is_some diffMaskOfDiff) true;
+  let diffMaskOfDiff = Option.get diffMaskOfDiff in
   if diffOfDiffPixels > 0 then (
     Bmp.IO.saveImage diffOutput "test-images/bmp/_diff-output.png";
     Png.IO.saveImage diffMaskOfDiff "test-images/bmp/_diff-of-diff.png"

--- a/test/Test_IO_JPG.ml
+++ b/test/Test_IO_JPG.ml
@@ -43,10 +43,14 @@ let test_creates_correct_diff_output_image () =
   let img1 = load_image "test-images/jpg/tiger.jpg" in
   let img2 = load_image "test-images/jpg/tiger-2.jpg" in
   let diffOutput, _, _, _ = Diff.compare img1 img2 () in
+  check bool "diffOutput" (Option.is_some diffOutput) true;
+  let diffOutput = Option.get diffOutput in
   let originalDiff = load_png_image "test-images/jpg/tiger-diff.png" in
   let diffMaskOfDiff, diffOfDiffPixels, diffOfDiffPercentage, _ =
     Output_Diff.compare originalDiff diffOutput ()
   in
+  check bool "diffMaskOfDiff" (Option.is_some diffMaskOfDiff) true;
+  let diffMaskOfDiff = Option.get diffMaskOfDiff in
   if diffOfDiffPixels > 0 then (
     Jpg.IO.saveImage diffOutput "test-images/jpg/_diff-output.png";
     Png.IO.saveImage diffMaskOfDiff "test-images/jpg/_diff-of-diff.png");

--- a/test/Test_IO_PNG.ml
+++ b/test/Test_IO_PNG.ml
@@ -40,10 +40,14 @@ let () =
               let img1 = load_image "test-images/png/orange.png" in
               let img2 = load_image "test-images/png/orange_changed.png" in
               let diffOutput, _, _, _ = Diff.compare img1 img2 () in
+              check bool "diffOutput" (Option.is_some diffOutput) true;
+              let diffOutput = Option.get diffOutput in
               let originalDiff = load_image "test-images/png/orange_diff.png" in
               let diffMaskOfDiff, diffOfDiffPixels, diffOfDiffPercentage, _ =
                 Diff.compare originalDiff diffOutput ()
               in
+              check bool "diffMaskOfDiff" (Option.is_some diffMaskOfDiff) true;
+              let diffMaskOfDiff = Option.get diffMaskOfDiff in
               if diffOfDiffPixels > 0 then (
                 Png.IO.saveImage diffOutput "test-images/png/diff-output.png";
                 Png.IO.saveImage diffMaskOfDiff

--- a/test/Test_IO_TIFF.ml
+++ b/test/Test_IO_TIFF.ml
@@ -49,12 +49,16 @@ let run_tiff_tests () =
               let img1 = load_tiff_image "test-images/tiff/laptops.tiff" in
               let img2 = load_tiff_image "test-images/tiff/laptops-2.tiff" in
               let diffOutput, _, _, _ = Diff.compare img1 img2 () in
+              check bool "diffOutput" (Option.is_some diffOutput) true;
+              let diffOutput = Option.get diffOutput in
               let originalDiff =
                 load_png_image "test-images/tiff/laptops-diff.png"
               in
               let diffMaskOfDiff, diffOfDiffPixels, diffOfDiffPercentage, _ =
                 Output_Diff.compare originalDiff diffOutput ()
               in
+              check bool "diffMaskOfDiff" (Option.is_some diffMaskOfDiff) true;
+              let diffMaskOfDiff = Option.get diffMaskOfDiff in
               if diffOfDiffPixels > 0 then (
                 Tiff.IO.saveImage diffOutput "test-images/tiff/_diff-output.png";
                 Png.IO.saveImage diffMaskOfDiff

--- a/test/Test_IO_TIFF.ml
+++ b/test/Test_IO_TIFF.ml
@@ -66,5 +66,5 @@ let run_tiff_tests () =
     ]
 
 let () =
-  if Sys.os_type == "Unix" then run_tiff_tests ()
+  if Sys.os_type = "Unix" then run_tiff_tests ()
   else print_endline "Skipping TIFF tests on Windows systems"


### PR DESCRIPTION
Images can be compared without saving the diff file.

`Main.ml` doesn't seem to have tests, so unsure if I should add any.

Fixes #64 