### PR TITLE
chore: remove upper version bound on ocaml

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -34,7 +34,7 @@
  (synopsis "Pixel-by-pixel image difference algorithm")
  (depends
   dune
-  (ocaml (= 5.2.0))
+  ocaml
  )
 )
 
@@ -44,7 +44,7 @@
  (depends
   dune
   odiff-core
-  (ocaml (= 5.2.0))
+  ocaml
   (dune-configurator (>= 3.16.0))
  )
 )

--- a/odiff-core.opam
+++ b/odiff-core.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/dmtrKovalenko/odiff"
 bug-reports: "https://github.com/dmtrKovalenko/odiff/issues"
 depends: [
   "dune" {>= "2.8"}
-  "ocaml" {= "5.2.0"}
+  "ocaml"
   "odoc" {with-doc}
 ]
 build: [

--- a/odiff-io.opam
+++ b/odiff-io.opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/dmtrKovalenko/odiff/issues"
 depends: [
   "dune" {>= "2.8"}
   "odiff-core"
-  "ocaml" {= "5.2.0"}
+  "ocaml"
   "dune-configurator" {>= "3.16.0"}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
OCaml version 5.2.1 is released. 

In general, I would remove the upper version bound on ocaml, as the backwards compatibility is pretty good.