### PR TITLE
Fix PNG missing IEND chunk

### DIFF
--- a/io/png_write/WritePng.c
+++ b/io/png_write/WritePng.c
@@ -117,6 +117,7 @@ value write_png_bigarray(value filename_val, value bigarray, value width_val, va
     caml_failwith(spng_strerror(result));
   }
 
+  spng_encode_chunks(ctx);
   spng_ctx_free(ctx);
   fclose(fp);
 


### PR DESCRIPTION
Per https://libspng.org/docs/encode/#spng_encode_chunks

"PNG must be explicitly finalized, this can be done with the SPNG_ENCODE_FINALIZE flag or with a call to spng_encode_chunks() after the image has been encoded."

This adds the finalization step for PNG, which was missing before. Now PNGs from odiff can be used for further processing via e.g. ghostscript, etc...

Fixes https://github.com/dmtrKovalenko/odiff/issues/109