### PR TITLE
fix(server): remove lingering stdin listeners in _writeWithBackpressure

### DIFF
--- a/npm_packages/odiff-bin/server.js
+++ b/npm_packages/odiff-bin/server.js
@@ -55,26 +55,36 @@ class ODiffServer {
 
         let settled = false;
 
-        stdin.once("drain", () => {
+        const onDrain = () => {
           if (!settled) {
             settled = true;
+            stdin.removeListener("error", onError);
+            stdin.removeListener("close", onClose);
             resolve(undefined);
           }
-        });
+        };
 
-        stdin.once("error", (err) => {
+        const onError = (err) => {
           if (!settled) {
             settled = true;
+            stdin.removeListener("drain", onDrain);
+            stdin.removeListener("close", onClose);
             reject(err);
           }
-        });
+        };
 
-        stdin.once("close", () => {
+        const onClose = () => {
           if (!settled) {
             settled = true;
+            stdin.removeListener("drain", onDrain);
+            stdin.removeListener("error", onError);
             reject(new Error("Stream closed before drain"));
           }
-        });
+        };
+
+        stdin.once("drain", onDrain);
+        stdin.once("error", onError);
+        stdin.once("close", onClose);
       });
     }
   }


### PR DESCRIPTION
## Problem

When `_writeWithBackpressure` needs to wait for `drain`, it registers three `once` listeners on `stdin`:

```js
stdin.once("drain", () => { ... resolve() });
stdin.once("error", (err) => { ... reject() });
stdin.once("close", () => { ... reject() });
```

When `drain` fires first, only the drain handler is auto-removed (by `once`). The `error` and `close` handlers are **never removed** — they linger on the stdin `Socket` indefinitely.

All writes to `ODiffServer` are serialized by `writeLock`, so listeners never pile up concurrently. Instead, they accumulate **sequentially**: every write that encounters backpressure and resolves via `drain` leaves behind one orphaned `error` listener and one orphaned `close` listener. After 11 such writes over the server's lifetime, the warning fires:

```
MaxListenersExceededWarning: Possible EventEmitter memory leak detected.
11 error listeners added to [Socket]. MaxListeners is 10.
```

## Fix

Convert the anonymous callbacks to named functions so each handler can explicitly remove the other two when it settles:

```js
const onDrain = () => {
  if (!settled) {
    settled = true;
    stdin.removeListener("error", onError);
    stdin.removeListener("close", onClose);
    resolve(undefined);
  }
};
// same pattern for onError and onClose
stdin.once("drain", onDrain);
stdin.once("error", onError);
stdin.once("close", onClose);
```

This ensures stdin's listener count stays bounded regardless of how many comparisons are run.