### PR TITLE
fix: transparent pixels whitening RGB of neighbouring pixels in AVX-512 path

### DIFF
--- a/src/test_avx.zig
+++ b/src/test_avx.zig
@@ -64,3 +64,66 @@ test "PNG: finds difference between 2 images without capture" {
     try expectEqual(@as(u32, 1366), diff_count); // diffPixels
     try expectApproxEqRel(@as(f64, 1.14), diff_percentage, 0.1); // diffPercentage
 }
+
+fn rgba(r: u8, g: u8, b: u8, a: u8) u32 {
+    return @as(u32, r) | (@as(u32, g) << 8) | (@as(u32, b) << 16) | (@as(u32, a) << 24);
+}
+
+fn makeImage(allocator: std.mem.Allocator, width: u32, height: u32, pixels: []const u32) !io.Image {
+    std.debug.assert(width * height == pixels.len);
+    const data = try allocator.dupe(u32, pixels);
+    return io.Image{
+        .data = data.ptr,
+        .len = data.len,
+        .width = width,
+        .height = height,
+    };
+}
+
+fn expectAsmDiffCount(allocator: std.mem.Allocator, width: u32, height: u32, pixels1: []const u32, pixels2: []const u32, expected: u32) !void {
+    var img1 = try makeImage(allocator, width, height, pixels1);
+    defer img1.deinit(allocator);
+
+    var img2 = try makeImage(allocator, width, height, pixels2);
+    defer img2.deinit(allocator);
+
+    const options = diff.DiffOptions{
+        .capture_diff = false,
+        .enable_asm = true,
+    };
+    var diff_output, const diff_count, _, var diff_lines, _ = try diff.compare(&img1, &img2, options, allocator);
+    defer if (diff_output) |*img| img.deinit(allocator);
+    defer if (diff_lines) |*lines| lines.deinit();
+
+    try expectEqual(expected, diff_count);
+}
+
+test "transparent pixel does not affect diff of neighbouring pixels" {
+    var gpa: std.heap.DebugAllocator(.{}) = .init;
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    // pixel 0 fully transparent in both images, pixel 1 black vs white
+    try expectAsmDiffCount(allocator, 4, 1, &.{
+        rgba(0, 0, 0, 0), rgba(0, 0, 0, 255), rgba(32, 64, 96, 255), rgba(96, 64, 32, 255),
+    }, &.{
+        rgba(0, 0, 0, 0), rgba(255, 255, 255, 255), rgba(32, 64, 96, 255), rgba(96, 64, 32, 255),
+    }, 1);
+
+    // transparent vs opaque black differs only in pixel 0
+    try expectAsmDiffCount(allocator, 4, 1, &.{
+        rgba(0, 0, 0, 0), rgba(5, 5, 5, 255), rgba(6, 6, 6, 255), rgba(7, 7, 7, 255),
+    }, &.{
+        rgba(0, 0, 0, 255), rgba(5, 5, 5, 255), rgba(6, 6, 6, 255), rgba(7, 7, 7, 255),
+    }, 1);
+
+    // same as the first case, but in the leftover path (width not divisible by 4):
+    // pixel 4 fully transparent in both images, pixel 5 black vs white
+    try expectAsmDiffCount(allocator, 7, 1, &.{
+        rgba(1, 2, 3, 255), rgba(4, 5, 6, 255), rgba(7, 8, 9, 255), rgba(10, 11, 12, 255),
+        rgba(0, 0, 0, 0),   rgba(0, 0, 0, 255), rgba(13, 14, 15, 255),
+    }, &.{
+        rgba(1, 2, 3, 255), rgba(4, 5, 6, 255), rgba(7, 8, 9, 255), rgba(10, 11, 12, 255),
+        rgba(0, 0, 0, 0),   rgba(255, 255, 255, 255), rgba(13, 14, 15, 255),
+    }, 1);
+}

--- a/src/vxdiff.asm
+++ b/src/vxdiff.asm
@@ -151,22 +151,22 @@ vxdiff:
 	kxor k6, k6, k6
 	kxor k7, k7, k7
 	vpcmpequb k6 {k4}, xmm1, xmm0
-	kshiftlb k6, k6, 1
+	kshiftrw k6, k6, 1
 	kor k7, k7, k6
-	kshiftlb k6, k6, 1
+	kshiftrw k6, k6, 1
 	kor k7, k7, k6
-	kshiftlb k6, k6, 1
+	kshiftrw k6, k6, 1
 	kor k7, k7, k6
 	vmovdqu8 xmm1 {k7}, xmm31
 	;
 	kxor k6, k6, k6
 	kxor k7, k7, k7
 	vpcmpequb k6 {k4}, xmm2, xmm0
-	kshiftlb k6, k6, 1
+	kshiftrw k6, k6, 1
 	kor k7, k7, k6
-	kshiftlb k6, k6, 1
+	kshiftrw k6, k6, 1
 	kor k7, k7, k6
-	kshiftlb k6, k6, 1
+	kshiftrw k6, k6, 1
 	kor k7, k7, k6
 	vmovdqu8 xmm2 {k7}, xmm31
 


### PR DESCRIPTION
Fixes issue reported here https://x.com/_can1357/status/2082143695881543721

The alpha=0 whitening block used kshiftlb to spread each alpha-byte match bit onto its pixel's RGB bytes, but shifting left moves the bit into the *next* pixel (and kshiftlb only covers 8 of the 16 mask bits). Use kshiftrw so the bit spreads down onto the same pixel's RGB bytes.